### PR TITLE
#166970205 An API endpoint to mark property as sold

### DIFF
--- a/SERVER/Controllers/properties.js
+++ b/SERVER/Controllers/properties.js
@@ -61,6 +61,22 @@ class Propertycontroller {
         }],
       });
   }
+
+  static markPropertySold(req, res) {
+    let markProperty = fields.Property.find(findid => findid.id === Number(req.params.id));
+    markProperty = {
+      status: req.body.status || recordFound.status,
+    };
+    const token = Helper.generateToken(markProperty.id);
+    return res.status(200)
+      .json({
+        status: '200',
+        data: [{
+          token,
+          markProperty,
+        }],
+      });
+  }
 }
 
 export default Propertycontroller;

--- a/SERVER/Middleware/validateProperties.js
+++ b/SERVER/Middleware/validateProperties.js
@@ -32,5 +32,24 @@ class ValidateProperties {
     }
     return next();
   }
+
+  static markPropertySold(req, res, next) {
+    const markproperty = fields.Property.find(findid => findid.id === Number(req.params.id));
+    if (!markproperty) {
+      res.status(404)
+        .json({
+          status: '404',
+          error: 'Please, this property can not be found',
+        });
+    }
+    if (!req.body.status) {
+      return res.status(400)
+        .json({
+          status: '400',
+          error: 'Please, supply the status',
+        });
+    }
+    return next();
+  }
 }
 export default ValidateProperties;

--- a/SERVER/Routes/index.js
+++ b/SERVER/Routes/index.js
@@ -13,5 +13,6 @@ router.post('/api/v1/auth/signUp', ValidateUsers.signUp, Usercontroller.signUp);
 router.post('/api/v1/auth/signin', ValidateUsers.signIn, Usercontroller.signIn);
 router.post('/api/v1/auth/postproperty', Auth.verifyToken, ValidateProperties.postproperty, Propertycontroller.postProperty);
 router.patch('/api/v1/auth/updateproperty/:id', Auth.verifyToken, ValidateProperties.updateproperty, Propertycontroller.updateProperty);
+router.patch('/api/v1/auth/markproperty/:id', Auth.verifyToken, ValidateProperties.markPropertySold, Propertycontroller.markPropertySold);
 
 export default router;

--- a/SERVER/Tests/propertiesTest.js
+++ b/SERVER/Tests/propertiesTest.js
@@ -211,3 +211,75 @@ describe('PATCH /api/v1/auth/updateproperty/:id ', () => {
       });
   });
 });
+
+describe('PATCH /api/v1/auth/markproperty/:id ', () => {
+  it('should mark a property as sold', (done) => {
+    const markproperty = {
+      status: 'Sold',
+    };
+    request(app)
+      .patch('/api/v1/auth/markproperty/2')
+      .set('Authorization', token)
+      .send(markproperty)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(200);
+        expect(res).to.have.status('200');
+        expect(res.body).to.include.key('data');
+        expect(res.body).to.include.key('status');
+        expect(res.body.data[0]).to.include.key('token');
+        expect(res.body.data[0]).to.include.key('markProperty');
+        done();
+      });
+  });
+
+  it('should return an error if token is not provided', (done) => {
+    const markproperty = {
+      status: 'Sold',
+    };
+    request(app)
+      .patch('/api/v1/auth/markproperty/2')
+      .send(markproperty)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(400);
+        expect(res).to.have.status('400');
+        expect(res.body).to.include.key('status');
+        expect(res.body).to.include.key('error');
+        expect(res.body.error).to.be.equal('Token is not provided');
+        done();
+      });
+  });
+  it('should return an error if a user does not supply the status field', (done) => {
+    const markproperty = {
+      status: '',
+    };
+    request(app)
+      .patch('/api/v1/auth/markproperty/2')
+      .set('Authorization', token)
+      .send(markproperty)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(400);
+        expect(res).to.have.status('400');
+        expect(res.body).to.include.key('status');
+        expect(res.body).to.include.key('error');
+        expect(res.body.error).to.be.equal('Please, supply the status');
+        done();
+      });
+  });
+  it('should return an error if property is not found', (done) => {
+    const markproperty = {
+      status: '',
+    };
+    request(app)
+      .patch('/api/v1/auth/markproperty/9')
+      .set('Authorization', token)
+      .send(markproperty)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(404);
+        expect(res).to.have.status('404');
+        expect(res.body).to.include.key('status');
+        expect(res.body).to.include.key('error');
+        expect(res.body.error).to.be.equal('Please, this property can not be found');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
**What does this PR do?**
An API endpoint for users mark-a-property-as-sold is created

**Description of tasks**
The following endpoint should be working;
PATCH /api/v1/auth/markproperty/:id

_after_
- creating a mark-property controller
- adding a middle ware validation for the mark-property controller
- creating a route for mark-property to access the endpoint

_finally_
- a test is written for mark-property

**How should this be manually tested/checked?**
After cloning this repo, cd into this project, run it by typing the command npm start, and test for the particular endpoint on postman, using localhost:5000/api/v1/auth/update-property
For the test, run **_npm test_**

**Any background context you want to provide?**
While testing, if you encounter any error and error messages, properly follow the error guidelines to get it working, this is so because the endpoint is well validated.

**What are the relevant pivotal tracker stories?**
<a href= "https://www.pivotaltracker.com/n/projects/2355287">#166970205</a>