### PR TITLE
#166970222 An endpoint to delete a property advert

### DIFF
--- a/SERVER/Controllers/properties.js
+++ b/SERVER/Controllers/properties.js
@@ -77,6 +77,22 @@ class Propertycontroller {
         }],
       });
   }
+
+  static deleteProperty(req, res) {
+    const id = parseInt(req.params.id, 10);
+    fields.Property.find((record, index) => {
+      if (record.id === id) {
+        fields.Property.splice(index, 1);
+        return res.status(200)
+          .json({
+            status: '200',
+            data: [{
+              message: 'Your property advert is deleted successfully',
+            }],
+          });
+      }
+    });
+  }
 }
 
 export default Propertycontroller;

--- a/SERVER/Middleware/validateProperties.js
+++ b/SERVER/Middleware/validateProperties.js
@@ -51,5 +51,17 @@ class ValidateProperties {
     }
     return next();
   }
+
+  static deleteProperty(req, res, next) {
+    const deleteProperty = fields.Property.find(findid => findid.id === Number(req.params.id));
+    if (!deleteProperty) {
+      res.status(404)
+        .json({
+          status: '404',
+          error: 'Please, this property can not be found',
+        });
+    }
+    return next();
+  }
 }
 export default ValidateProperties;

--- a/SERVER/Routes/index.js
+++ b/SERVER/Routes/index.js
@@ -14,5 +14,5 @@ router.post('/api/v1/auth/signin', ValidateUsers.signIn, Usercontroller.signIn);
 router.post('/api/v1/auth/postproperty', Auth.verifyToken, ValidateProperties.postproperty, Propertycontroller.postProperty);
 router.patch('/api/v1/auth/updateproperty/:id', Auth.verifyToken, ValidateProperties.updateproperty, Propertycontroller.updateProperty);
 router.patch('/api/v1/auth/markproperty/:id', Auth.verifyToken, ValidateProperties.markPropertySold, Propertycontroller.markPropertySold);
-
+router.delete('/api/v1/auth/deleteproperty/:id', Auth.verifyToken, ValidateProperties.deleteProperty, Propertycontroller.deleteProperty);
 export default router;

--- a/SERVER/Tests/propertiesTest.js
+++ b/SERVER/Tests/propertiesTest.js
@@ -283,3 +283,47 @@ describe('PATCH /api/v1/auth/markproperty/:id ', () => {
       });
   });
 });
+
+describe('DELETE /api/v1/auth/deleteproperty/:id ', () => {
+  it('should delete a property', (done) => {
+    request(app)
+      .delete('/api/v1/auth/deleteproperty/2')
+      .set('Authorization', token)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(200);
+        expect(res).to.have.status('200');
+        expect(res.body).to.include.key('data');
+        expect(res.body).to.include.key('status');
+        expect(res.body.data[0]).to.include.key('message');
+        expect(res.body.data[0].message).to.be.equal('Your property advert is deleted successfully');
+        done();
+      });
+  });
+
+  it('should return an error if token is not provided', (done) => {
+    request(app)
+      .delete('/api/v1/auth/deleteproperty/2')
+      .end((err, res) => {
+        expect(res.status).to.be.equal(400);
+        expect(res).to.have.status('400');
+        expect(res.body).to.include.key('status');
+        expect(res.body).to.include.key('error');
+        expect(res.body.error).to.be.equal('Token is not provided');
+        done();
+      });
+  });
+
+  it('should return an error if the record is not found', (done) => {
+    request(app)
+      .delete('/api/v1/auth/deleteproperty/12')
+      .set('Authorization', token)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(404);
+        expect(res).to.have.status('404');
+        expect(res.body).to.include.key('status');
+        expect(res.body).to.include.key('error');
+        expect(res.body.error).to.be.equal('Please, this property can not be found');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
**What does this PR do?**
An API endpoint for users delete-property is created

**Description of tasks**
The following endpoint should be working;
DELETE /api/v1/auth/deleteproperty/:id

_after_
- a controller is created to delete property adverts
- a validation created to handle errors
- a test written for the endpoint 

**How should this be manually tested/checked?**
After cloning this repo, cd into this project, run it by typing the command npm start, and test for the particular endpoint on postman, using localhost:5000/api/v1/auth/update-property
For the test, run **_npm test_**

**Any background context you want to provide?**
While testing, if you encounter any error and error messages, properly follow the error guidelines to get it working, this is so because the endpoint is well validated.

**What are the relevant pivotal tracker stories?**
<a href = "https://www.pivotaltracker.com/n/projects/2355287">#166970222</a>