### PR TITLE
feat(specificType): user should get specific types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,8 @@ module.exports = {
   },
   rules: {
       "linebreak-style": 0,
-      "no-undef": 0,  
+      "no-undef": 0, 
+      "array-callback-return": 0, 
+      "consistent-return": 0,
   },
 };

--- a/SERVER/Controllers/properties.js
+++ b/SERVER/Controllers/properties.js
@@ -114,8 +114,23 @@ class Propertycontroller {
           status: '200',
           token,
           data: [{
-          property,
-          }]
+            property,
+          }],
+        });
+    }
+  }
+
+  static propertytype(req, res) {
+    const property = fields.Property[req.params.id].type;
+    if (property) {
+      const token = Helper.generateToken();
+      return res.status(200)
+        .json({
+          status: '200',
+          token,
+          data: [{
+            property,
+          }],
         });
     }
   }

--- a/SERVER/Routes/index.js
+++ b/SERVER/Routes/index.js
@@ -17,4 +17,5 @@ router.patch('/api/v1/auth/markproperty/:id', Auth.verifyToken, ValidateProperti
 router.delete('/api/v1/auth/deleteproperty/:id', Auth.verifyToken, ValidateProperties.deleteProperty, Propertycontroller.deleteProperty);
 router.get('/api/v1/auth/allproperties', Auth.verifyToken, Propertycontroller.allproperties);
 router.get('/api/v1/auth/property/:id', Auth.verifyToken, ValidateProperties.property, Propertycontroller.property);
+router.get('/api/v1/auth/propertytype/:id', Auth.verifyToken, Propertycontroller.propertytype);
 export default router;


### PR DESCRIPTION
**What does this PR do?**
An API endpoint for users to get specific types  is created

**Description of tasks**
The following endpoint should be working;
GET /api/v1/auth/propertytype/:id

after
- creating a controller for a user to get a specific type
- creating a route to access the endpoint
- disabling some rules in the eslint file

**How should this be manually tested/checked?**
After cloning this repo, cd into this project, run it by typing the command _**npm start**_, and test for the particular endpoint on postman, using localhost:5000/api/v1/auth/propertytype/:id

**Any background context you want to provide?**
While testing, if you encounter any error and error messages, properly follow the error guidelines to get it working, this is so because the endpoint is well validated.

**What are the relevant pivotal tracker stories?**
<a href= "https://www.pivotaltracker.com/story/show/166970258">166970258</a>