### PR TITLE
 #167269481 An API  endpoint mark a property as sold - [persisting data to a DB]

### DIFF
--- a/SERVER/Controllers/properties.js
+++ b/SERVER/Controllers/properties.js
@@ -41,6 +41,32 @@ class Propertycontroller {
       data: values,
     });
   }
+
+  static async markPropertySold(req, res) {
+    const markPropertyQuery = 'SELECT * FROM Property WHERE property_id=$1';
+    const { rows } = await db.query(markPropertyQuery, [req.params.property_id]);
+    const token = Helper.generateToken(rows[0].property_id);
+    const { property_id } = req.params;
+    const {
+      type, state, city, address, price, created_on, image_url,
+    } = req.body;
+    const values = {
+      property_id,
+      status: req.body.status = 'sold',
+      type,
+      state,
+      city,
+      address,
+      price,
+      created_on,
+      image_url,
+    };
+    return res.status(200).json({
+      status: 'success',
+      token,
+      data: values,
+    });
+  }
 }
 
 export default Propertycontroller;

--- a/SERVER/Routes/propertyRoute.js
+++ b/SERVER/Routes/propertyRoute.js
@@ -17,4 +17,7 @@ propertyRoute.patch('/property/:property_id',
   ValidateProperties.updateProperty,
   Propertycontroller.updateProperty);
 
+propertyRoute.patch('/property/:property_id/sold',
+  Propertycontroller.markPropertySold);
+
 export default propertyRoute;


### PR DESCRIPTION
**What does this PR do?**
An API endpoint for users(agent) to mark a property as sold

**Description of tasks**
The following endpoint should be working;
**PATCH** /api/v1/property/18/sold

**_after_**

- creating an endpoint [controller] to mark a property as sold
- creating a route to access it

**How should this be manually tested/checked?**
After cloning this repo, cd into this project, run it by typing the command _**npm start,**_ and test for the particular endpoint on postman, using localhost:5000/api/v1/property/18/sold
For the test, run _**npm test**_

**What are the relevant pivotal tracker stories?**
<a href = "https://www.pivotaltracker.com/story/show/167269481">167269481</a>