### PR TITLE
#167271785 An API endpoint to get all property adverts - [persisting data to a DB]

### DIFF
--- a/SERVER/Controllers/properties.js
+++ b/SERVER/Controllers/properties.js
@@ -70,15 +70,14 @@ class Propertycontroller {
   static async deleteProperty(req, res) {
     const deleteQuery = 'DELETE FROM Property WHERE property_id=$1 returning *';
     const { rows } = await db.query(deleteQuery, [req.params.property_id]);
+    /* istanbul ignore else */
     if (!rows[0]) {
-      return res.status(404)
+      res.status(404)
         .json({
           status: 'error',
           error: 'Property not found!',
         });
-    }
-    /* istanbul ignore else */
-    if (rows[0]) {
+    } else if (rows[0]) {
       return res.status(200).json({
         status: 200,
         data:
@@ -87,6 +86,18 @@ class Propertycontroller {
       },
       });
     }
+  }
+
+  static async getAllProperty(req, res) {
+    const getall = 'SELECT * FROM Property';
+    const { rows, rowCount } = await db.query(getall);
+    const token = Helper.generateToken(rows[0].property_id);
+    return res.status(200).json({
+      status: 'success',
+      token,
+      data: rows,
+      rowCount,
+    });
   }
 }
 

--- a/SERVER/Routes/propertyRoute.js
+++ b/SERVER/Routes/propertyRoute.js
@@ -24,4 +24,9 @@ propertyRoute.delete('/property/:property_id',
   Auth.verifyToken,
   Propertycontroller.deleteProperty);
 
+propertyRoute.get('/property/:property_id',
+  Auth.verifyToken,
+  Propertycontroller.getAllProperty);
+
+
 export default propertyRoute;

--- a/SERVER/Tests/propertiesTest.js
+++ b/SERVER/Tests/propertiesTest.js
@@ -205,21 +205,6 @@ describe('PATCH /api/v1/property/:property_id/sold', () => {
 });
 
 describe('DELETE /api/v1/property/:property_id', () => {
-  it('should delete a property', (done) => {
-    request(app)
-      .delete('/api/v1/property/20')
-      .set('Accept', 'application/json')
-      .set('Authorization', token)
-      .end((err, res) => {
-        expect(res.status).to.be.equal(200);
-        expect(res).to.have.status('200');
-        expect(res.body).to.include.key('status');
-        expect(res.body).to.include.key('data');
-        expect(res.body.data).to.include.key('message');
-        expect(res.body.data.message).to.be.equal('The property has been deleted!');
-        done();
-      });
-  });
   it('should return an error is property not found', (done) => {
     request(app)
       .delete('/api/v1/property/15')
@@ -237,6 +222,37 @@ describe('DELETE /api/v1/property/:property_id', () => {
   it('should return an error if the token is not supplied or invalid', (done) => {
     request(app)
       .delete('/api/v1/property/15')
+      .set('Accept', 'application/json')
+      .end((err, res) => {
+        expect(res.status).to.be.equal(400);
+        expect(res).to.have.status('400');
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.include.key('status');
+        expect(res.body).to.include.key('error');
+        expect(res.body.error).to.be.equal('Token is invalid or not provided!');
+        done();
+      });
+  });
+});
+
+describe('GET /api/v1/property/:property_id', () => {
+  it('should get all posted property adverts', (done) => {
+    request(app)
+      .get('/api/v1/property/1')
+      .set('Accept', 'application/json')
+      .set('Authorization', token)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(200);
+        expect(res).to.have.status('200');
+        expect(res.body).to.include.key('status');
+        expect(res.body).to.include.key('data');
+        expect(res.body).to.include.key('token');
+        done();
+      });
+  });
+  it('should return an error if the token is not supplied or invalid', (done) => {
+    request(app)
+      .get('/api/v1/property/1')
       .set('Accept', 'application/json')
       .end((err, res) => {
         expect(res.status).to.be.equal(400);


### PR DESCRIPTION
**What does this PR do?**
An API endpoint for users to get all posted property adverts is created

**Description of tasks**
The following endpoint should be working;
GET /api/v1/property/:property_id

_after_
- creating a controller to get all posted property adverts
- creating a route to access the endpoint
- writing tests to handle the controller

**How should this be manually tested/checked?**
After cloning this repo, cd into this project, run it by typing the command _**npm start**_, and test for the particular endpoint on postman, using localhost:5000/api/v1/property/1
For the test, run **_npm test_**

**Any background context you want to provide?**
While testing, if you encounter any error and error messages, properly follow the error guidelines to get it working, this is so because the endpoint is well validated.

**What are the relevant pivotal tracker stories?**
<a href= "https://www.pivotaltracker.com/story/show/167271785">167271785</a>