### PR TITLE
#167271890 An API endpoint to get a property advert -[persisting data to a DB]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ cache:
     - "node_modules" 
 after_success:
   - npm run coverage
-
+  - npm run coveralls
  

--- a/SERVER/Controllers/properties.js
+++ b/SERVER/Controllers/properties.js
@@ -99,6 +99,17 @@ class Propertycontroller {
       rowCount,
     });
   }
+
+  static async getAProperty(req, res) {
+    const getone = 'SELECT * FROM Property WHERE property_id = $1';
+    const { rows } = await db.query(getone, [req.params.property_id]);
+    const token = Helper.generateToken(rows[0].property_id);
+    return res.status(200).json({
+      status: 'success',
+      token,
+      data: rows[0],
+    });
+  }
 }
 
 export default Propertycontroller;

--- a/SERVER/Middleware/validateProperties.js
+++ b/SERVER/Middleware/validateProperties.js
@@ -38,7 +38,21 @@ class ValidateProperties {
         });
     }
 
-    return next();
+    next();
+  }
+
+  static async getAProperty(req, res, next) {
+    const getone = 'SELECT * FROM Property WHERE property_id = $1';
+    const { rows } = await db.query(getone, [req.params.property_id]);
+    if (!rows[0]) {
+      return res.status(404)
+        .json({
+          status: 'error',
+          error: 'Property not found!',
+        });
+    }
+
+    next();
   }
 }
 export default ValidateProperties;

--- a/SERVER/Routes/propertyRoute.js
+++ b/SERVER/Routes/propertyRoute.js
@@ -24,9 +24,14 @@ propertyRoute.delete('/property/:property_id',
   Auth.verifyToken,
   Propertycontroller.deleteProperty);
 
-propertyRoute.get('/property/:property_id',
+propertyRoute.get('/property',
   Auth.verifyToken,
   Propertycontroller.getAllProperty);
+
+propertyRoute.get('/property/:property_id',
+  Auth.verifyToken,
+  ValidateProperties.getAProperty,
+  Propertycontroller.getAProperty);
 
 
 export default propertyRoute;

--- a/SERVER/Tests/propertiesTest.js
+++ b/SERVER/Tests/propertiesTest.js
@@ -235,6 +235,37 @@ describe('DELETE /api/v1/property/:property_id', () => {
   });
 });
 
+describe('GET /api/v1/property', () => {
+  it('should get all posted property adverts', (done) => {
+    request(app)
+      .get('/api/v1/property')
+      .set('Accept', 'application/json')
+      .set('Authorization', token)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(200);
+        expect(res).to.have.status('200');
+        expect(res.body).to.include.key('status');
+        expect(res.body).to.include.key('data');
+        expect(res.body).to.include.key('token');
+        done();
+      });
+  });
+  it('should return an error if the token is not supplied or invalid', (done) => {
+    request(app)
+      .get('/api/v1/property')
+      .set('Accept', 'application/json')
+      .end((err, res) => {
+        expect(res.status).to.be.equal(400);
+        expect(res).to.have.status('400');
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.include.key('status');
+        expect(res.body).to.include.key('error');
+        expect(res.body.error).to.be.equal('Token is invalid or not provided!');
+        done();
+      });
+  });
+});
+
 describe('GET /api/v1/property/:property_id', () => {
   it('should get all posted property adverts', (done) => {
     request(app)
@@ -247,6 +278,21 @@ describe('GET /api/v1/property/:property_id', () => {
         expect(res.body).to.include.key('status');
         expect(res.body).to.include.key('data');
         expect(res.body).to.include.key('token');
+        done();
+      });
+  });
+  it('should return an error if the property is not found', (done) => {
+    request(app)
+      .get('/api/v1/property/1001')
+      .set('Accept', 'application/json')
+      .set('Authorization', token)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(404);
+        expect(res).to.have.status('404');
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.include.key('status');
+        expect(res.body).to.include.key('error');
+        expect(res.body.error).to.be.equal('Property not found!');
         done();
       });
   });


### PR DESCRIPTION
**What does this PR do?**
An API endpoint for users to get a property advert is created

**Description of tasks**
The following endpoint should be working;
GET **/api/v1/property/:property_id**

_after_
- creating a controller to get/view a property advert
- creating a route to access the endpoint
- updated [travis config]
- creating validations to handle the controller
- write tests for the controller[endpoint]

**How should this be manually tested/checked?**
After cloning this repo, cd into this project, run it by typing the command _**npm start,**_ and test for the particular endpoint on postman, using localhost:5000/ api/v1/property/:property_id
For the test, run **_npm test_**

**Any background context you want to provide?**
While testing, if you encounter any error and error messages, properly follow the error guidelines to get it working, this is so because the endpoint is well validated.

**What are the relevant pivotal tracker stories?**
<a href = "https://www.pivotaltracker.com/story/show/167271890">167271890</a>